### PR TITLE
Add ability to pass arguments via cli

### DIFF
--- a/.github/workflows/publish_exe.yml
+++ b/.github/workflows/publish_exe.yml
@@ -18,9 +18,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
 
-    - run: pip install -e .
-    - run: pip install -U setuptools==69.5.1
-    - run: pip install -U pyinstaller==6.6.0
+    - run: pip install -e .[publish]
     - run: pip list
     - run: pyinstaller src/aind_watchdog_service/main.py --onefile --noconsole  -n aind-watchdog-service -i src/aind_watchdog_service/icon/watchdog.ico --clean
     # Verify the executable runs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,11 @@ dev = [
     'furo',
 ]
 
+publish = [
+    'setuptools==69.5.1',
+    'pyinstaller==6.6.0',
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/aind_watchdog_service/event_handler.py
+++ b/src/aind_watchdog_service/event_handler.py
@@ -8,7 +8,7 @@ from typing import Dict
 
 import yaml
 from apscheduler.schedulers.background import BackgroundScheduler
-from watchdog.events import FileModifiedEvent, FileSystemEventHandler
+from watchdog.events import FileCreatedEvent, FileSystemEventHandler
 
 from aind_watchdog_service.alert_bot import AlertBot
 from aind_watchdog_service.models.manifest_config import ManifestConfig
@@ -29,12 +29,12 @@ class EventHandler(FileSystemEventHandler):
         if config.webhook_url:
             self.alert = AlertBot(config.webhook_url)
 
-    def _load_manifest(self, event: FileModifiedEvent) -> ManifestConfig:
+    def _load_manifest(self, event: FileCreatedEvent) -> ManifestConfig:
         """Instructions to transfer to VAST
 
         Parameters
         ----------
-        event : FileModifiedEvent
+        event : FileCreatedEvent
            file modified event
 
         Returns
@@ -50,12 +50,12 @@ class EventHandler(FileSystemEventHandler):
             except Exception as e:
                 logging.error("Error loading config %s", repr(e))
 
-    def _remove_job(self, event: FileModifiedEvent) -> None:
+    def _remove_job(self, event: FileCreatedEvent) -> None:
         """Removes job from scheduler queue
 
         Parameters
         ----------
-        event : FileModifiedEvent
+        event : FileCreatedEvent
            event to remove
         """
         if self.jobs.get(event.src_path, ""):
@@ -81,15 +81,15 @@ class EventHandler(FileSystemEventHandler):
         trigger_time = dt.now().replace(hour=hour, minute=0, second=0, microsecond=0)
         if (trigger_time - dt.now()).total_seconds() < 0:
             trigger_time = trigger_time + timedelta(days=1)
-        print(f"Trigger time {trigger_time}")
+        logging.info(f"Trigger time {trigger_time}")
         return trigger_time
 
-    def schedule_job(self, event: FileModifiedEvent, job_config: ManifestConfig) -> None:
+    def schedule_job(self, event: FileCreatedEvent, job_config: ManifestConfig) -> None:
         """Schedule job to run
 
         Parameters
         ----------
-        event : FileModifiedEvent
+        event : FileCreatedEvent
             event to trigger job
         config : dict
             configuration for the job
@@ -106,12 +106,12 @@ class EventHandler(FileSystemEventHandler):
             job_id = self.scheduler.add_job(run.run_job, "date", run_date=trigger)
         self.jobs[event.src_path] = job_id
 
-    def on_deleted(self, event: FileModifiedEvent) -> None:
+    def on_deleted(self, event: FileCreatedEvent) -> None:
         """Event handler for file deleted event
 
         Parameters
         ----------
-        event : FileModifiedEvent
+        event : FileCreatedEvent
             file deleted event
 
         Returns
@@ -125,12 +125,12 @@ class EventHandler(FileSystemEventHandler):
             self._remove_job(self.jobs[event.src_path].id)
         logging.info("Jobs in queue %s", self.scheduler.get_jobs())
 
-    def on_modified(self, event: FileModifiedEvent) -> None:
+    def on_created(self, event: FileCreatedEvent) -> None:
         """Event handler for file modified event
 
         Parameters
         ----------
-        event : FileModifiedEvent
+        event : FileCreatedEvent
             file modified event
 
         Returns

--- a/src/aind_watchdog_service/main.py
+++ b/src/aind_watchdog_service/main.py
@@ -92,6 +92,7 @@ def start_watchdog(watch_config: WatchConfig) -> None:
 
 
 def main():
+    """Main function to parse arguments and start watchdog service"""
 
     parser = argparse.ArgumentParser(description="Watchdog service")
     parser.add_argument(

--- a/src/aind_watchdog_service/main.py
+++ b/src/aind_watchdog_service/main.py
@@ -125,8 +125,11 @@ def main():
         logging.error("If passing --flag-dir or --manifest-complete, both are required!")
         sys.exit(1)
 
+    watch_config: WatchConfig
+
     if (args.flag_dir is not None) and (args.manifest_complete is not None):
         try:
+
             watch_config = WatchConfig(
                 flag_dir=args.flag_dir,
                 manifest_complete=args.manifest_complete,
@@ -161,7 +164,7 @@ def main():
                 logging.error("Error loading config %s", e)
                 sys.exit(1)
 
-        start_watchdog(watch_config)
+    start_watchdog(watch_config)
 
 
 if __name__ == "__main__":

--- a/src/aind_watchdog_service/main.py
+++ b/src/aind_watchdog_service/main.py
@@ -1,5 +1,6 @@
 """ Main module to start the watchdog observer and scheduler """
 
+import argparse
 import logging
 import os
 import sys
@@ -8,6 +9,7 @@ from pathlib import Path
 
 import yaml
 from apscheduler.schedulers.background import BackgroundScheduler
+from pydantic import ValidationError
 from watchdog.observers import Observer
 
 from aind_watchdog_service.event_handler import EventHandler
@@ -82,24 +84,84 @@ class WatchdogService:
         self.initiate_observer()
 
 
-def start_watchdog(config: dict) -> None:
+def start_watchdog(watch_config: WatchConfig) -> None:
     """Load configuration, initiate WatchdogService and start service"""
-    try:
-        watch_config = WatchConfig(**config)
-    except Exception as e:
-        logging.error("Error loading config %s", e)
-        sys.exit(1)
+
     watchdog_service = WatchdogService(watch_config)
     watchdog_service.start_service()
 
 
-if __name__ == "__main__":
-    configuration = os.getenv("WATCH_CONFIG")
-    if not configuration:
-        logging.error("Environment variable WATCH_CONFIG not set. Please set and restart")
-        raise AttributeError(
-            "Environment variable WATCH_CONFIG not set. Please set and restart"
+def main():
+
+    parser = argparse.ArgumentParser(description="Watchdog service")
+    parser.add_argument(
+        "-c",
+        "--config-path",
+        type=str,
+        help="Configuration file for watchdog service. Takes precedence over environment \
+            variable WATCH_CONFIG and other arguments",
+    )
+    parser.add_argument(
+        "-f", "--flag-dir", type=str, help="Directory for watchdog to poll"
+    )
+    parser.add_argument(
+        "-m",
+        "--manifest-complete",
+        type=str,
+        help="Manifest directory for triggered data",
+    )
+    parser.add_argument(
+        "-w", "--webhook-url", type=str, help="Teams webhook url for user notification"
+    )
+
+    args = parser.parse_args()
+
+    if args.config_path:
+        args.flag_dir = None
+        args.manifest_complete = None
+
+    if (args.flag_dir is None) ^ (args.manifest_complete is None):
+        logging.error("If passing --flag-dir or --manifest-complete, both are required!")
+        sys.exit(1)
+
+    if (args.flag_dir is not None) and (args.manifest_complete is not None):
+        try:
+            watch_config = WatchConfig(
+                flag_dir=args.flag_dir,
+                manifest_complete=args.manifest_complete,
+                webhook_url=args.webhook_url,
+            )
+        except ValidationError as e:
+            logging.error(
+                "Error constructing WatchConfig model from cli arguments: %s", e
+            )
+    else:
+        configuration = (
+            args.config_path if args.config_path else os.getenv("WATCH_CONFIG")
         )
-    with open(configuration) as y:
-        data = yaml.safe_load(y)
-    start_watchdog(data)
+
+        if not configuration:
+            logging.error(
+                "Environment variable WATCH_CONFIG not set and a path was not passed.\
+                    Please set and restart"
+            )
+            raise AttributeError(
+                "Environment variable WATCH_CONFIG not set. Please set and restart"
+            )
+        if not Path(configuration).exists():
+            logging.error("Configuration file %s does not exist", configuration)
+            raise FileNotFoundError(f"Configuration file {configuration} does not exist")
+
+        with open(configuration, encoding="UTF-8") as y:
+            data = yaml.safe_load(y)
+            try:
+                watch_config = WatchConfig(**data)
+            except ValidationError as e:
+                logging.error("Error loading config %s", e)
+                sys.exit(1)
+
+        start_watchdog(watch_config)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aind_watchdog_service/run_job.py
+++ b/src/aind_watchdog_service/run_job.py
@@ -14,7 +14,7 @@ from aind_data_transfer_models.core import (
     ModalityConfigs,
     SubmitJobRequest,
 )
-from watchdog.events import FileModifiedEvent
+from watchdog.events import FileCreatedEvent
 
 from aind_watchdog_service.alert_bot import AlertBot
 from aind_watchdog_service.models.manifest_config import ManifestConfig
@@ -33,7 +33,7 @@ class RunJob:
 
     def __init__(
         self,
-        event: FileModifiedEvent,
+        event: FileCreatedEvent,
         config: ManifestConfig,
         watch_config: WatchConfig,
         alert: Union[str, None],
@@ -252,7 +252,7 @@ class RunJob:
 
         Parameters
         ----------
-        event : FileModifiedEvent
+        event : FileCreatedEvent
             modified event file
         """
         logging.info("Running job for %s", self.event.src_path)

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -8,15 +8,15 @@ from unittest.mock import MagicMock, patch
 
 import yaml
 from apscheduler.schedulers.background import BackgroundScheduler
-from watchdog.events import FileModifiedEvent
+from watchdog.events import FileCreatedEvent
 
 from aind_watchdog_service.event_handler import EventHandler
 from aind_watchdog_service.models.manifest_config import ManifestConfig
 from aind_watchdog_service.models.watch_config import WatchConfig
 
 
-class MockFileModifiedEvent(FileModifiedEvent):
-    """Mock FileModifiedEvent for testing EventHandler"""
+class MockFileCreatedEvent(FileCreatedEvent):
+    """Mock FileCreatedEvent for testing EventHandler"""
 
     def __init__(self, src_path):
         """init"""
@@ -67,21 +67,21 @@ class TestEventHandler(unittest.TestCase):
     @patch("logging.info")
     @patch("aind_watchdog_service.event_handler.EventHandler._load_manifest")
     @patch("aind_watchdog_service.event_handler.EventHandler.schedule_job")
-    def test_event_handler_on_modified(
+    def test_event_handler_on_created(
         self,
         mock_schedule_job: MagicMock,
         mock_vast_transfer: MagicMock,
         mock_log_info: MagicMock,
     ):
-        """Test on_modified method"""
+        """Test on_created method"""
 
         mock_vast_transfer.return_value = ManifestConfig(**self.manifest_config)
         mock_scheduler = MockScheduler()
 
         watch_config = WatchConfig(**self.config)
         event_handler = EventHandler(mock_scheduler, watch_config)
-        mock_event = MockFileModifiedEvent("/path/to/manifest.txt")
-        event_handler.on_modified(mock_event)
+        mock_event = MockFileCreatedEvent("/path/to/manifest.txt")
+        event_handler.on_created(mock_event)
         with patch.object(Path, "is_dir") as mock_dir:
             mock_dir.return_value = False
             mock_log_info.assert_called_with("Found event file %s", mock_event.src_path)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import yaml
 from apscheduler.schedulers.background import BackgroundScheduler
-from watchdog.events import FileModifiedEvent
+from watchdog.events import FileCreatedEvent
 from watchdog.observers import Observer
 
 from aind_watchdog_service.event_handler import EventHandler
@@ -16,8 +16,8 @@ from aind_watchdog_service.models.watch_config import WatchConfig
 TEST_DIRECTORY = Path(__file__).resolve().parent
 
 
-class MockFileModifiedEvent(FileModifiedEvent):
-    """Mock FileModifiedEvent for testing EventHandler"""
+class MockFileCreatedEvent(FileCreatedEvent):
+    """Mock FileCreatedEvent for testing EventHandler"""
 
     def __init__(self, src_path):
         """init"""
@@ -81,7 +81,7 @@ class TestWatchdogService(unittest.TestCase):
         with open(watch_config_fp) as yam:
             cls.watch_config_dict = yaml.safe_load(yam)
         cls.watch_config = WatchConfig(**cls.watch_config_dict)
-        cls.mock_event = MockFileModifiedEvent("/path/to/file.txt")
+        cls.mock_event = MockFileCreatedEvent("/path/to/file.txt")
 
     @patch("aind_watchdog_service.main.WatchdogService._setup_logging")
     @patch("logging.error")

--- a/tests/test_run_job.py
+++ b/tests/test_run_job.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import requests
 import yaml
-from watchdog.events import FileModifiedEvent
+from watchdog.events import FileCreatedEvent
 
 from aind_watchdog_service.models.manifest_config import ManifestConfig
 from aind_watchdog_service.models.watch_config import WatchConfig
@@ -17,8 +17,8 @@ from aind_watchdog_service.run_job import RunJob
 TEST_DIRECTORY = Path(__file__).resolve().parent
 
 
-class MockFileModifiedEvent(FileModifiedEvent):
-    """Mock FileModifiedEvent for testing EventHandler"""
+class MockFileCreatedEvent(FileCreatedEvent):
+    """Mock FileCreatedEvent for testing EventHandler"""
 
     def __init__(self, src_path):
         """init"""
@@ -57,7 +57,7 @@ class TestRunSubprocess(unittest.TestCase):
         cls.manifest_config = ManifestConfig(**manifest_config)
         cls.manifest_with_run_script = ManifestConfig(**manifest_with_run_script)
         cls.manifest_config_upload_only = ManifestConfig(**manifest_upload_only)
-        cls.mock_event = MockFileModifiedEvent("/path/to/file.txt")
+        cls.mock_event = MockFileCreatedEvent("/path/to/file.txt")
         cls.run_script_config = manifest_with_run_script
 
     @patch("subprocess.run")


### PR DESCRIPTION
This PR allows passing arguments via the cli interface:

The current order of priorities is:
 - if a path is passed to `-c`, it will be used as the target to find the config yml file
 - if `-c` is not passed, and `-m` and `-f` are set, they will be used to construct the `WatchConfig` model. If `-m` or `-f` are set, both must be set
 - Finally, if no arguments are passed (fully backward compatible) the application will default to try to find the file via the environment variables.

The PR also adds an initial check (fail early) if the target yml file doesn't exist.

``` cmd
python .\src\aind_watchdog_service\main.py --help
usage: main.py [-h] [-c CONFIG_PATH] [-f FLAG_DIR] [-m MANIFEST_COMPLETE] [-w WEBHOOK_URL]

Watchdog service

options:
  -h, --help            show this help message and exit
  -c CONFIG_PATH, --config-path CONFIG_PATH
                        Configuration file for watchdog service. Takes precedence over environment variable WATCH_CONFIG and other arguments
  -f FLAG_DIR, --flag-dir FLAG_DIR
                        Directory for watchdog to poll
  -m MANIFEST_COMPLETE, --manifest-complete MANIFEST_COMPLETE
                        Manifest directory for triggered data
  -w WEBHOOK_URL, --webhook-url WEBHOOK_URL
                        Teams webhook url for user notification

```


Fixes #30 