### PR TITLE
Build pin aind data schemas models

### DIFF
--- a/.github/workflows/publish_exe.yml
+++ b/.github/workflows/publish_exe.yml
@@ -20,7 +20,7 @@ jobs:
 
     - run: pip install -e .[publish]
     - run: pip list
-    - run: pyinstaller src/aind_watchdog_service/main.py --onefile --noconsole  -n aind-watchdog-service -i src/aind_watchdog_service/icon/watchdog.ico --clean
+    - run: python build_watchdog.py
     # Verify the executable runs
     - run: copy examples/example_watch_config_no_webhook.yml ./dist/
     - run: set WATCH_CONFIG=dist/example_watch_config_no_webhook.yml

--- a/build_watchdog.py
+++ b/build_watchdog.py
@@ -1,0 +1,25 @@
+"""Build watchdog service executable"""
+
+from importlib_resources import files
+from PyInstaller import __main__ as pyi
+
+
+def main():
+    """Build watchdog service executable using PyInstaller
+    """
+    args = [
+        "src/aind_watchdog_service/main.py",
+        "--name",
+        "aind-watchdog-service",
+        "-i",
+        "src/aind_watchdog_service/icon/watchdog.ico",
+        "--additional-hooks-dir=.",
+        "--console",
+        "--onefile",
+        "--clean"
+    ]
+    pyi.run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/hook-aind_data_schema_models.py
+++ b/hook-aind_data_schema_models.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('aind_data_schema_models', include_py_files=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     'watchdog',
     'pyyaml',
     'aind-data-transfer-models',
+    'aind-data-schema-models>=0.4',
     'APScheduler',
     'requests'
 ]

--- a/src/aind_watchdog_service/main.py
+++ b/src/aind_watchdog_service/main.py
@@ -23,7 +23,8 @@ class WatchdogService:
     def __init__(
         self,
         watch_config: WatchConfig,
-        log_dir: Path = "C:/ProgramData/aind/aind-watchdog-service",
+        log_dir: Path = Path(os.getenv("PROGRAMDATA", "C:/ProgramData"))
+        / "aind/aind-watchdog-service",
     ):
         """Construct WatchDogService, setup logging
 

--- a/src/aind_watchdog_service/models/manifest_config.py
+++ b/src/aind_watchdog_service/models/manifest_config.py
@@ -61,12 +61,10 @@ class ManifestConfig(BaseModel):
         title="Destination directory",
         examples=[r"\\allen\aind\scratch\test"],
     )
-    modalities: Dict[Literal[tuple(Modality.abbreviation_map.keys())], List[str]] = (
-        Field(
-            default={},
-            description="list of ModalityFile objects containing modality names and associated files or directories",  # noqa
-            title="modality files",
-        )
+    modalities: Dict[Literal[tuple(Modality.abbreviation_map.keys())], List[str]] = Field(
+        default={},
+        description="list of ModalityFile objects containing modality names and associated files or directories",  # noqa
+        title="modality files",
     )
     schemas: List[str] = Field(
         default=[],

--- a/src/aind_watchdog_service/models/manifest_config.py
+++ b/src/aind_watchdog_service/models/manifest_config.py
@@ -42,7 +42,7 @@ class ManifestConfig(BaseModel):
         description="Transfer endpoint for data transfer",
         title="Transfer endpoint",
     )
-    platform: Literal[tuple(Platform._abbreviation_map.keys())] = Field(
+    platform: Literal[tuple(Platform.abbreviation_map.keys())] = Field(
         description="Platform type", title="Platform type"
     )
     capsule_id: Optional[str] = Field(
@@ -61,7 +61,7 @@ class ManifestConfig(BaseModel):
         title="Destination directory",
         examples=[r"\\allen\aind\scratch\test"],
     )
-    modalities: Dict[Literal[tuple(Modality._abbreviation_map.keys())], List[str]] = (
+    modalities: Dict[Literal[tuple(Modality.abbreviation_map.keys())], List[str]] = (
         Field(
             default={},
             description="list of ModalityFile objects containing modality names and associated files or directories",  # noqa

--- a/src/aind_watchdog_service/models/manifest_config.py
+++ b/src/aind_watchdog_service/models/manifest_config.py
@@ -3,11 +3,14 @@
 from datetime import datetime, time
 from typing import Dict, List, Literal, Optional
 
-from aind_data_schema_models.modalities import Modality
-from aind_data_schema_models.platforms import Platform
+from aind_data_schema_models import modalities
+from aind_data_schema_models import platforms
 from aind_data_transfer_models.core import BucketType
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from typing_extensions import Self
+
+Platforms = tuple(set(platforms.Platform.abbreviation_map.keys()))
+Modality = tuple(set(list(modalities.Modality.abbreviation_map.keys()) + ["ophys"]))
 
 
 class ManifestConfig(BaseModel):
@@ -42,7 +45,7 @@ class ManifestConfig(BaseModel):
         description="Transfer endpoint for data transfer",
         title="Transfer endpoint",
     )
-    platform: Literal[tuple(Platform.abbreviation_map.keys())] = Field(
+    platform: Literal[Platforms] = Field(
         description="Platform type", title="Platform type"
     )
     capsule_id: Optional[str] = Field(
@@ -61,7 +64,7 @@ class ManifestConfig(BaseModel):
         title="Destination directory",
         examples=[r"\\allen\aind\scratch\test"],
     )
-    modalities: Dict[Literal[tuple(Modality.abbreviation_map.keys())], List[str]] = Field(
+    modalities: Dict[Literal[Modality], List[str]] = Field(
         default={},
         description="list of ModalityFile objects containing modality names and associated files or directories",  # noqa
         title="modality files",

--- a/tests/resources/manifest.yml
+++ b/tests/resources/manifest.yml
@@ -13,7 +13,7 @@ modalities:
   - D:\behavior\data\1330132892_Behavior_20240212T091443.json
   - D:\behavior\data\1330132892_Face_20240212T091444.json
   - D:\behavior\data\1330132892_Eye_20240212T091443.json
-  ophys:
+  pophys:
   - D:\data\1330132892\1330132892_averaged_depth.tiff
   - D:\data\1330132892\1330132892_averaged_surface.tiff
   - D:\data\1330132892\1330132892_cortical_z_stack0.tiff

--- a/tests/resources/manifest_upload_only.yaml
+++ b/tests/resources/manifest_upload_only.yaml
@@ -13,7 +13,7 @@ modalities:
   - D:\behavior\data\1330132892_Behavior_20240212T091443.json
   - D:\behavior\data\1330132892_Face_20240212T091444.json
   - D:\behavior\data\1330132892_Eye_20240212T091443.json
-  ophys:
+  pophys:
   - D:\data\1330132892\1330132892_averaged_depth.tiff
   - D:\data\1330132892\1330132892_averaged_surface.tiff
   - D:\data\1330132892\1330132892_cortical_z_stack0.tiff


### PR DESCRIPTION
This PR updates the watchdog to be compatible with aind-data-schemas-models >=0.4. 
This update will break compatibility with versions prior to 0.4 since the previous "_abbreviation_map" has now been renamed to "abbreviation_map" and `ophys` is no longer a valid modality as it has been superseded by `pophys`.


Closes #48 