### PR TITLE
Allow using aind-data-schema-models classes natively

### DIFF
--- a/src/aind_watchdog_service/models/manifest_config.py
+++ b/src/aind_watchdog_service/models/manifest_config.py
@@ -62,10 +62,10 @@ class ManifestConfig(BaseModel):
     )
     platform: Platform = Field(description="Platform type", title="Platform type")
     capsule_id: Optional[str] = Field(
-        ..., description="Capsule ID of pipeline to run", title="Capsule"
+        default=None, description="Capsule ID of pipeline to run", title="Capsule"
     )
     mount: Optional[str] = Field(
-        ..., description="Mount point for pipeline run", title="Mount point"
+        default=None, description="Mount point for pipeline run", title="Mount point"
     )
     s3_bucket: BucketType = Field(
         default=BucketType.PRIVATE, description="s3 endpoint", title="S3 endpoint"

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -89,6 +89,9 @@ class TestManifestConfigs(unittest.TestCase):
                 processor_full_name="na",
                 subject_id="007",
                 acquisition_datetime=dt(2024, 9, 3, 13, 38, 48, 36456),
+                project_name="no project",
+                mount=None,
+                capsule_id=None,
             )
 
         self.assertEqual(

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -88,7 +88,7 @@ class TestManifestConfigs(unittest.TestCase):
                 schemas=["path"],
                 processor_full_name="na",
                 subject_id="007",
-                acquisition_datetime=dt.now(),
+                acquisition_datetime=dt(2024, 9, 3, 13, 38, 48, 36456),
                 project_name="no project",
                 mount=None,
                 capsule_id=None,

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pydantic_core
 import yaml
+from aind_data_schema_models import modalities, platforms
 from pydantic import ValidationError
 
 from aind_watchdog_service.models.manifest_config import ManifestConfig
@@ -69,6 +70,37 @@ class TestManifestConfigs(unittest.TestCase):
         data["modalities"]["nikon"] = ["some file"]
         with self.assertRaises(ValidationError):
             ManifestConfig(**data)
+
+    def test_manifest_from_platform_modalities(self):
+        """Test the manifest from platform modalities."""
+
+        modality = getattr(modalities.Modality, "BEHAVIOR", None)
+        self.assertIsNotNone(modality)
+        platform = getattr(platforms.Platform, "BEHAVIOR", None)
+        self.assertIsNotNone(platform)
+
+        def _create_manifest(modality, platform) -> ManifestConfig:
+            return ManifestConfig(
+                name="test",
+                destination="path",
+                modalities={modality: ["path"]},
+                platform=platform,
+                schemas=["path"],
+                processor_full_name="na",
+                subject_id="007",
+                acquisition_datetime=dt.now(),
+                project_name="no project",
+                mount=None,
+                capsule_id=None,
+            )
+
+        self.assertEqual(
+            _create_manifest(modality=modality, platform=platform),
+            _create_manifest(
+                modality=getattr(modality, "abbreviation"),
+                platform=getattr(platform, "abbreviation"),
+            ),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #58 

Unfortunately, because these classes are implemented upstream it's hard to provide proper type hints and still ensure proper schema compilation. This is the best I could think of for now.

