### PR TITLE
Set optional manifest config values to None

### DIFF
--- a/src/aind_watchdog_service/models/manifest_config.py
+++ b/src/aind_watchdog_service/models/manifest_config.py
@@ -62,10 +62,10 @@ class ManifestConfig(BaseModel):
     )
     platform: Platform = Field(description="Platform type", title="Platform type")
     capsule_id: Optional[str] = Field(
-        ..., description="Capsule ID of pipeline to run", title="Capsule"
+        default=None, description="Capsule ID of pipeline to run", title="Capsule"
     )
     mount: Optional[str] = Field(
-        ..., description="Mount point for pipeline run", title="Mount point"
+        default=None, description="Mount point for pipeline run", title="Mount point"
     )
     s3_bucket: BucketType = Field(
         default=BucketType.PRIVATE, description="s3 endpoint", title="S3 endpoint"

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -89,6 +89,9 @@ class TestManifestConfigs(unittest.TestCase):
                 processor_full_name="na",
                 subject_id="007",
                 acquisition_datetime=dt(2024, 9, 3, 13, 38, 48, 36456),
+                project_name="no project",
+                mount=None,
+                capsule_id=None,
             )
 
         self.assertEqual(


### PR DESCRIPTION
Keeping consistent with other optional config parameters. If optional, default to None.